### PR TITLE
Added optional hooks into walltowall run for CBM4:

### DIFF
--- a/gcbmwalltowall/runner/cbm4.py
+++ b/gcbmwalltowall/runner/cbm4.py
@@ -4,7 +4,7 @@ import json
 import os
 import shutil
 import time
-from typing import Any
+from typing import Any, Callable
 from tempfile import TemporaryDirectory
 import pandas as pd
 from cbm4.app.spatial.spatial_cbm3.spatial_cbm3_app import (
@@ -61,7 +61,12 @@ def load_config(
     return simulation_config, spinup_config, step_configs
 
 
-def run(cbm4_config_path: str | Path, **kwargs):
+def run(
+    cbm4_config_path: str | Path,
+    on_pre_spinup: Callable[[str]] | None = None,
+    on_pre_simulation: Callable[[str]] | None = None,
+    **kwargs
+):
     json_config = json.load(open(cbm4_config_path))
     sim_start_year = int(json_config["start_year"])
 
@@ -81,9 +86,19 @@ def run(cbm4_config_path: str | Path, **kwargs):
     create_simulation_dataset(simulation_config)
     step_times.append(["create simulation dataset", (time.time() - start)])
 
+    if on_pre_spinup is not None:
+        start = time.time()
+        on_pre_spinup(simulation_config["out_simulation_dataset"]["path_or_uri"])
+        step_times.append(["pre-spinup callback", (time.time() - start)])
+
     start = time.time()
     spinup_all(spinup_config)
     step_times.append(["spinup", (time.time() - start)])
+
+    if on_pre_simulation is not None:
+        start = time.time()
+        on_pre_simulation(simulation_config["out_simulation_dataset"]["path_or_uri"])
+        step_times.append(["pre-simulation callback", (time.time() - start)])
 
     with TemporaryDirectory() as tmp:
         event_processor = EventProcessor.for_simulation(cbm4_root, tmp)

--- a/gcbmwalltowall/runner/cbmspec.py
+++ b/gcbmwalltowall/runner/cbmspec.py
@@ -5,7 +5,7 @@ import os
 import shutil
 import time
 from tempfile import TemporaryDirectory
-from typing import Any
+from typing import Any, Callable
 
 import pandas as pd
 from arrow_space.raster_indexed_dataset import RasterIndexedDataset
@@ -32,6 +32,8 @@ def run(
     cbm4_config_path: str | Path,
     max_workers: int = None,
     write_parameters: bool = False,
+    on_pre_spinup: Callable[[str]] | None = None,
+    on_pre_simulation: Callable[[str]] | None = None,
     **kwargs,
 ):
     json_config = kwargs.get("json_config") or load_config(cbm4_config_path, **kwargs)
@@ -93,6 +95,11 @@ def run(
         )
     )
 
+    if on_pre_spinup is not None:
+        start = time.time()
+        on_pre_spinup(json_config["cbm4_spatial_dataset"]["simulation"]["path_or_uri"])
+        step_times.append(["pre-spinup callback", (time.time() - start)])
+
     start = time.time()
     cbm4_spatial_runner.spinup_all(
         model=cbmspec_cbm3_single_matrix_model,
@@ -104,7 +111,11 @@ def run(
     )
     step_times.append(["spinup", (time.time() - start)])
 
-    sim_start_year = int(json_config["start_year"])
+    if on_pre_simulation is not None:
+        start = time.time()
+        on_pre_simulation(json_config["cbm4_spatial_dataset"]["simulation"]["path_or_uri"])
+        step_times.append(["pre-simulation callback", (time.time() - start)])
+
     final_timestep = json_config["end_year"] - json_config["start_year"] + 1
     with TemporaryDirectory() as tmp:
         event_processor = EventProcessor.for_simulation(str(out_path.absolute()), tmp)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gcbmwalltowall"
-version = "2.7.6"
+version = "2.8.0"
 description = "gcbmwalltowall"
 classifiers = ["Programming Language :: Python :: 3"]
 requires-python = ">=3.9"


### PR DESCRIPTION
  - on_pre_spinup(simulation_dataset_path)
  - on_pre_simulation(simulation_dataset_path)

giving custom workflows the ability to modify the simulation dataset using callbacks, while otherwise using the normal run logic.